### PR TITLE
Fix: Resolve offline player NPEs and command execution errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-paper-core</artifactId>
-            <version>11.0.0</version>
+            <version>11.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/eu/vibemc/lifesteal/commands/HeartsCommands.java
+++ b/src/main/java/eu/vibemc/lifesteal/commands/HeartsCommands.java
@@ -29,6 +29,10 @@ public class HeartsCommands {
                 .executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int amount = (int) args.get("amount");
                     player.getAttribute(Attribute.MAX_HEALTH).setBaseValue(player.getAttribute(Attribute.MAX_HEALTH).getBaseValue() + amount);
                     player.sendMessage(Config.getMessage("heartAdded").replace("${amount}", String.valueOf(amount / 2)));
@@ -44,6 +48,10 @@ public class HeartsCommands {
                 .executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int amount = (int) args.get("amount");
                     player.getAttribute(Attribute.MAX_HEALTH).setBaseValue(amount);
                     player.sendMessage(Config.getMessage("heartSetted").replace("${amount}", String.valueOf(amount / 2)));
@@ -60,6 +68,10 @@ public class HeartsCommands {
                 .executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int amount = (int) args.get("amount");
                     player.getAttribute(Attribute.MAX_HEALTH).setBaseValue(player.getAttribute(Attribute.MAX_HEALTH).getBaseValue() - amount);
                     player.sendMessage(Config.getMessage("heartRemoved").replace("${amount}", String.valueOf(amount / 2)));
@@ -76,6 +88,10 @@ public class HeartsCommands {
                 .executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int amount = (int) player.getAttribute(Attribute.MAX_HEALTH).getBaseValue();
                     sender.sendMessage(Config.getMessage("heartCheck").replace("${amount}", String.valueOf(amount / 2)).replace("${player}", player.getName()));
                 });

--- a/src/main/java/eu/vibemc/lifesteal/commands/ItemsCommands.java
+++ b/src/main/java/eu/vibemc/lifesteal/commands/ItemsCommands.java
@@ -24,6 +24,10 @@ public class ItemsCommands {
                 .withArguments(new PlayerProfileArgument("player"), new IntegerArgument("chance_of_success"), new IntegerArgument("amount")).executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int chance = (int) args.get("chance_of_success");
                     int amount = (int) args.get("amount");
                     for (int i = 0; i < amount; i++) {
@@ -40,6 +44,10 @@ public class ItemsCommands {
                 executes((sender, args) -> {
                     List<PlayerProfile> profiles = (List<PlayerProfile>) args.get("player");
                     Player player = org.bukkit.Bukkit.getPlayer(profiles.getFirst().getUniqueId());
+                    if (player == null) {
+                        sender.sendMessage("§cPlayer must be online.");
+                        return;
+                    }
                     int amount = (int) args.get("amount");
                     for (int i = 0; i < amount; i++) {
                         player.getInventory().addItem(Items.ReviveBook.getReviveBook());

--- a/src/main/java/eu/vibemc/lifesteal/events/PlayerJoin.java
+++ b/src/main/java/eu/vibemc/lifesteal/events/PlayerJoin.java
@@ -40,7 +40,7 @@ public class PlayerJoin implements Listener {
             int max = Config.getInt("heartItem.addLimit") > Config.getInt("killHeartLimit") ? Config.getInt("heartItem.addLimit") : Config.getInt("killHeartLimit");
             // if player's max health is bigger than max, set max health to max
             if (Config.getInt("killHeartLimit") > 0 && Config.getInt("heartItem.addLimit") > 0 && max > 0 && player.getAttribute(Attribute.MAX_HEALTH).getBaseValue() > max) {
-                System.out.println(player.getAttribute(Attribute.MAX_HEALTH).getBaseValue() + " > " + max);
+                Main.getInstance().getLogger().info(player.getAttribute(Attribute.MAX_HEALTH).getBaseValue() + " > " + max);
                 player.getAttribute(Attribute.MAX_HEALTH).setBaseValue(max);
                 player.sendMessage(Config.getMessage("abuseDetected"));
                 player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_LAND, 100, 1);

--- a/src/main/java/eu/vibemc/lifesteal/other/CommandAPIDependency.java
+++ b/src/main/java/eu/vibemc/lifesteal/other/CommandAPIDependency.java
@@ -12,21 +12,29 @@ import java.util.logging.Logger;
 
 public class CommandAPIDependency {
 
-    private static final String COMMANDAPI_VERSION = "11.0.0";
+    private static final String COMMANDAPI_VERSION = "11.1.0";
     private static final String COMMANDAPI_JAR = "CommandAPI-" + COMMANDAPI_VERSION + "-Paper.jar";
-    private static final String DOWNLOAD_URL = "https://github.com/CommandAPI/CommandAPI/releases/download/" + COMMANDAPI_VERSION + "/" + COMMANDAPI_JAR;
+    private static final String DOWNLOAD_URL = "https://github.com/CommandAPI/CommandAPI/releases/download/"
+            + COMMANDAPI_VERSION + "/" + COMMANDAPI_JAR;
 
     public static boolean ensureInstalled(Logger logger) {
-        File pluginsFolder = new File("plugins");
+        File pluginsFolder = eu.vibemc.lifesteal.Main.getInstance().getDataFolder().getParentFile();
+        if (pluginsFolder == null || !pluginsFolder.exists() || !pluginsFolder.isDirectory()) {
+            logger.severe("Could not find the plugins folder.");
+            return false;
+        }
         File commandApiFile = new File(pluginsFolder, COMMANDAPI_JAR);
 
         if (Bukkit.getPluginManager().getPlugin("CommandAPI") != null) {
             return true;
         }
 
-        for (File file : pluginsFolder.listFiles()) {
-            if (file.getName().startsWith("CommandAPI-") && file.getName().endsWith(".jar")) {
-                return true;
+        File[] files = pluginsFolder.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.getName().startsWith("CommandAPI-") && file.getName().endsWith(".jar")) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
- Bumped CommandAPI to v11.1.0 in pom.xml and auto-downloader
- Added robust null checks for offline players in HeartsCommands and ItemsCommands to prevent NPEs
- Fixed CommandAPIDependency listFiles() NullPointerException when plugin folder didn't exist
- Updated CommandAPIDependency to dynamically grab the correct plugin folder path
- Replaced raw System.out.println with the Bukkit logger in PlayerJoin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to ensure players are online when executing heart and item commands; offline players now receive an appropriate error message.
  * Improved server plugin detection and loading with enhanced error handling.

* **Chores**
  * Updated CommandAPI dependency to version 11.1.0.
  * Enhanced logging for server diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->